### PR TITLE
Correct FQDN in warning

### DIFF
--- a/sa2d
+++ b/sa2d
@@ -14,8 +14,8 @@ set atsign [string trimleft $atsign @]
 spawn sh -c "openssl s_client -ign_eof -quiet -brief root.atsign.wtf:64 2>/dev/null"
 
 expect {
-timeout { send_user "Connection failed to get an @ prompt at root.atsign.org:64" }
-eof { send_user "Connection failed to root.atsign.org:64" }
+timeout { send_user "Connection failed to get an @ prompt at root.atsign.wtf:64" }
+eof { send_user "Connection failed to root.atsign.wtf:64" }
 "@"
 }
 


### PR DESCRIPTION
**- What I did**

s/org/wtf/ for warning messages so that the source of any issues is clear.

**- Description for the changelog**

Correct FQDN in warning