### PR TITLE
Look for data:[ instead of a public key

### DIFF
--- a/checksecondary.expect
+++ b/checksecondary.expect
@@ -22,7 +22,7 @@ send "scan\r"
 expect {
 timeout { send_user "Scan failed on port $port\n"; exit 1}
 eof { send_user "Scan failed on port $port\n"; exit 1}
-"signing_publickey@"
+"data:["
 }
 
 send "\003"


### PR DESCRIPTION
Fixes #8 

**- What I did**

The expect script now checks for liveness by getting a `data:[` response rather than expecting a public key (as it seems that people are [unwisely] deleting keys from their secondaries, which was causing false alarms in monitoring).

**- How to verify it**

This change has already been put into production on hornet-01

**- Description for the changelog**

Look for data:[ instead of a public key